### PR TITLE
Fix OpenToCustomHooks

### DIFF
--- a/include/Hooks.hpp
+++ b/include/Hooks.hpp
@@ -32,3 +32,4 @@ struct __PCRegister##func { \
 static __PCRegister##func __PCRegisterInstance##func;
 
 #define SIMPLE_INSTALL_HOOK(identifier) INSTALL_HOOK(logger, identifier);
+#define SIMPLE_INSTALL_HOOK_ORIG(identifier) INSTALL_HOOK_ORIG(logger, identifier);

--- a/qpm.json
+++ b/qpm.json
@@ -43,6 +43,11 @@
       "additionalData": {
         "private": true
       }
+    },
+    {
+      "id": "libil2cpp",
+      "versionRange": "^0.2.3",
+      "additionalData": {}
     }
   ],
   "additionalData": {}

--- a/qpm.json
+++ b/qpm.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "questui",
-      "versionRange": "*",
+      "versionRange": "^0.11.1",
       "additionalData": {
         "private": true
       }

--- a/qpm.json
+++ b/qpm.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "id": "beatsaber-hook",
-      "versionRange": "*",
+      "versionRange": "=2.3.0",
       "additionalData": {
         "extraFiles": [
           "src/inline-hook"
@@ -29,12 +29,12 @@
     },
     {
       "id": "custom-types",
-      "versionRange": "*",
+      "versionRange": "^0.12.7",
       "additionalData": {}
     },
     {
       "id": "codegen",
-      "versionRange": "*",
+      "versionRange": "^0.14.0",
       "additionalData": {}
     },
     {

--- a/src/Hooks/OpenToCustomHooks.cpp
+++ b/src/Hooks/OpenToCustomHooks.cpp
@@ -19,7 +19,7 @@
 MAKE_HOOK_MATCH(LevelFilteringNavigationController_Setup, &GlobalNamespace::LevelFilteringNavigationController::Setup, void, GlobalNamespace::LevelFilteringNavigationController* self, GlobalNamespace::SongPackMask songPackMask, GlobalNamespace::IBeatmapLevelPack* levelPackToBeSelectedAfterPresent, GlobalNamespace::SelectLevelCategoryViewController::LevelCategory startLevelCategory, bool hidePacksIfOneOrNone, bool enableCustomLevels)
 {
 	LevelFilteringNavigationController_Setup(self, songPackMask, levelPackToBeSelectedAfterPresent, startLevelCategory, hidePacksIfOneOrNone, enableCustomLevels);
-	
+
 	if (levelPackToBeSelectedAfterPresent == nullptr && config.openToCustomLevels && enableCustomLevels) {
 		self->selectLevelCategoryViewController->Setup(startLevelCategory.CustomSongs, self->enabledLevelCategories);
 	}
@@ -27,7 +27,7 @@ MAKE_HOOK_MATCH(LevelFilteringNavigationController_Setup, &GlobalNamespace::Leve
 
 void InstallOpenToCustomHooks(Logger& logger)
 {
-	SIMPLE_INSTALL_HOOK(LevelFilteringNavigationController_Setup);
+	SIMPLE_INSTALL_HOOK_ORIG(LevelFilteringNavigationController_Setup);
 }
 
 // using a macro to register the method pointer to the class that stores all of the install methods, for automatic execution


### PR DESCRIPTION
No idea why honestly but if it's not INSTALL_HOOK_ORIG the LevelSelection screen freezes on opening when MQE has customs set to disabled