### PR TITLE
Fix crash on difficultyBeatmap nullptr

### DIFF
--- a/src/Hooks/SongColourHooks.cpp
+++ b/src/Hooks/SongColourHooks.cpp
@@ -72,7 +72,7 @@ MAKE_AUTO_HOOK_MATCH(StandardLevelScenesTransitionSetupDataSO_Init, &StandardLev
 
 MAKE_AUTO_HOOK_MATCH(MultiplayerLevelScenesTransitionSetupDataSO_Init, &MultiplayerLevelScenesTransitionSetupDataSO::Init, void, MultiplayerLevelScenesTransitionSetupDataSO* self, StringW gameMode, IPreviewBeatmapLevel* previewBeatmapLevel, BeatmapDifficulty beatmapDifficulty, BeatmapCharacteristicSO* beatmapCharacteristic, IDifficultyBeatmap* difficultyBeatmap, ColorScheme* overrideColorScheme, GameplayModifiers* gameplayModifiers, PlayerSpecificSettings* playerSpecificSettings, PracticeSettings* practiceSettings, bool useTestNoteCutSoundEffects)
 {
-	if(!SongUtils::SongInfo::isCustom(previewBeatmapLevel)){ 
+	if(!difficultyBeatmap || !SongUtils::SongInfo::isCustom(previewBeatmapLevel)){ 
 		MultiplayerLevelScenesTransitionSetupDataSO_Init(self, gameMode, previewBeatmapLevel, beatmapDifficulty, beatmapCharacteristic, difficultyBeatmap, overrideColorScheme, gameplayModifiers, playerSpecificSettings, practiceSettings, useTestNoteCutSoundEffects);
 		return;
 	}


### PR DESCRIPTION
When joining a lobby in Multiplayer where a map is currently being played that can't be played, for example DLC not being owned, the game sets difficultyBeatmap to nullptr to indicate that the player should be put into spectator with the not owned message.
This fixes the crash that happens with PinkCore trying to access data on a nullptr difficultyBeatmap.